### PR TITLE
Document CubeIDE integration steps for TIM3 PWM helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# PWM Library for STM32F446RE
+
+This example shows how to configure TIM3 to produce a 1.8 kHz PWM signal with
+software limits for duty-cycle control between 7 % and 94 %. The code is
+structured as a small reusable library (`tim3_pwm`) that can be called from
+`main.c`.
+
+## Files
+
+- `inc/tim3_pwm.h`: Public API for the PWM helper.
+- `src/tim3_pwm.c`: Implementation of the TIM3 PWM configuration and runtime
+  helpers.
+- `src/main.c`: Minimal example demonstrating how to use the helper from the
+  application.
+
+## Uso directo en proyectos simples
+
+1. Asegúrate de que los controladores HAL de STM32 estén en tu proyecto y que
+   las rutas de inclusión apunten al directorio `inc`.
+2. Llama a `TIM3_PWM_Init()` con el canal deseado (el canal 1 corresponde al
+   pin PA6 en la placa Nucleo-F446RE).
+3. Usa `TIM3_PWM_SetDutyCycle()` para actualizar el ciclo útil; la librería
+   aplica automáticamente los límites entre 7 % y 94 %.
+
+Ajusta `SystemClock_Config()` para que coincida con el árbol de relojes de tu
+proyecto si no usas la configuración generada por CubeMX.
+
+## Integración en STM32CubeIDE
+
+1. **Genera el proyecto base en CubeMX/CubeIDE.**
+   - Selecciona la placa STM32F446RE o el microcontrolador equivalente.
+   - Configura el reloj del sistema (por ejemplo, HSI a 16 MHz o HSE a 84 MHz)
+     según tus necesidades.
+   - No es necesario activar TIM3 ni sus GPIO desde CubeMX, porque la librería
+     se encarga de habilitar los relojes y configurar los pines.
+   - Genera el código y abre el proyecto en STM32CubeIDE.
+
+2. **Copia los archivos de la librería.**
+   - Añade `inc/tim3_pwm.h` al directorio `Core/Inc/` (o crea una carpeta
+     `Drivers/Custom/inc` y agrega esa ruta a los includes).
+   - Añade `src/tim3_pwm.c` al directorio `Core/Src/` (o al que prefieras para
+     tu código de aplicación).
+   - Si guardas los archivos en una carpeta personalizada, abre
+     *Project Properties → C/C++ General → Paths and Symbols* y añade la ruta
+     al apartado *Includes* de GCC.
+
+3. **Incluye la cabecera en `main.c`.**
+   ```c
+   #include "tim3_pwm.h"
+   ```
+
+4. **Inicializa el temporizador tras `SystemClock_Config()`.**
+   Inserta el siguiente bloque en la sección `/* USER CODE BEGIN 2 */` de
+   `main.c`:
+   ```c
+   if (TIM3_PWM_Init(TIM_CHANNEL_1) != HAL_OK)
+   {
+       Error_Handler();
+   }
+   if (TIM3_PWM_SetDutyCycle(TIM_CHANNEL_1, 50.0f) != HAL_OK)
+   {
+       Error_Handler();
+   }
+   ```
+   Sustituye `TIM_CHANNEL_1` por el canal que quieras usar:
+   - Canal 1 → PA6
+   - Canal 2 → PA7
+   - Canal 3 → PB0
+   - Canal 4 → PB1
+
+5. **Compila y programa.**
+   - La librería calcula automáticamente el período para 1.8 kHz en función de
+     la frecuencia real del bus APB1, por lo que no necesitas ajustar
+     manualmente el valor del ARR.
+   - Ajusta el ciclo útil en tiempo de ejecución mediante
+     `TIM3_PWM_SetDutyCycle()` dentro del bucle principal o en interrupciones.
+
+6. **Opcional:** Si tu aplicación utiliza la función débil `HAL_TIM_MspPostInit`
+   generada por CubeMX para configurar los pines de PWM, puedes dejarla vacía o
+   eliminar la configuración redundante. La librería inicializa los GPIO antes
+   de arrancar el PWM, por lo que no habrá conflictos.
+
+Con estos pasos tendrás el PWM de TIM3 funcionando en tu proyecto de
+STM32CubeIDE con los límites de ciclo útil definidos.

--- a/inc/tim3_pwm.h
+++ b/inc/tim3_pwm.h
@@ -1,0 +1,22 @@
+#ifndef TIM3_PWM_H
+#define TIM3_PWM_H
+
+#include "stm32f4xx_hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TIM3_PWM_FREQUENCY_HZ 1800U
+#define TIM3_PWM_MIN_DUTY_PERCENT 7.0f
+#define TIM3_PWM_MAX_DUTY_PERCENT 94.0f
+
+HAL_StatusTypeDef TIM3_PWM_Init(uint32_t channel);
+HAL_StatusTypeDef TIM3_PWM_SetDutyCycle(uint32_t channel, float duty_percent);
+TIM_HandleTypeDef *TIM3_PWM_GetHandle(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TIM3_PWM_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,39 @@
+#include "stm32f4xx_hal.h"
+#include "tim3_pwm.h"
+
+static void SystemClock_Config(void);
+static void Error_Handler(void);
+
+int main(void)
+{
+    HAL_Init();
+    SystemClock_Config();
+
+    if (TIM3_PWM_Init(TIM_CHANNEL_1) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    if (TIM3_PWM_SetDutyCycle(TIM_CHANNEL_1, 50.0f) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    while (1)
+    {
+        /* Application code */
+    }
+}
+
+static void SystemClock_Config(void)
+{
+    /* Configure system clock as required by the application */
+}
+
+static void Error_Handler(void)
+{
+    __disable_irq();
+    while (1)
+    {
+    }
+}

--- a/src/tim3_pwm.c
+++ b/src/tim3_pwm.c
@@ -1,0 +1,161 @@
+#include "tim3_pwm.h"
+
+#include <stdbool.h>
+
+static TIM_HandleTypeDef s_tim3_handle;
+static bool s_initialized = false;
+
+static void TIM3_PWM_EnableClocks(void);
+static void TIM3_PWM_InitGPIO(uint32_t channel);
+static uint32_t TIM3_PWM_CalculatePeriod(uint32_t target_frequency_hz);
+TIM_HandleTypeDef *TIM3_PWM_GetHandle(void)
+{
+    return &s_tim3_handle;
+}
+
+HAL_StatusTypeDef TIM3_PWM_Init(uint32_t channel)
+{
+    TIM_OC_InitTypeDef pwm_config = {0};
+    HAL_StatusTypeDef status;
+
+    TIM3_PWM_EnableClocks();
+    TIM3_PWM_InitGPIO(channel);
+
+    s_tim3_handle.Instance = TIM3;
+    s_tim3_handle.Init.Prescaler = 0;
+    s_tim3_handle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    s_tim3_handle.Init.Period = TIM3_PWM_CalculatePeriod(TIM3_PWM_FREQUENCY_HZ);
+    s_tim3_handle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    s_tim3_handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+
+    status = HAL_TIM_PWM_Init(&s_tim3_handle);
+    if (status != HAL_OK)
+    {
+        return status;
+    }
+
+    pwm_config.OCMode = TIM_OCMODE_PWM1;
+    pwm_config.Pulse = 0;
+    pwm_config.OCPolarity = TIM_OCPOLARITY_HIGH;
+    pwm_config.OCFastMode = TIM_OCFAST_DISABLE;
+
+    status = HAL_TIM_PWM_ConfigChannel(&s_tim3_handle, &pwm_config, channel);
+    if (status != HAL_OK)
+    {
+        return status;
+    }
+
+    s_initialized = true;
+
+    return TIM3_PWM_SetDutyCycle(channel, TIM3_PWM_MIN_DUTY_PERCENT);
+}
+
+HAL_StatusTypeDef TIM3_PWM_SetDutyCycle(uint32_t channel, float duty_percent)
+{
+    uint32_t period;
+    float clamped;
+    uint32_t pulse;
+
+    if (!s_initialized)
+    {
+        return HAL_ERROR;
+    }
+
+    if (duty_percent < TIM3_PWM_MIN_DUTY_PERCENT)
+    {
+        clamped = TIM3_PWM_MIN_DUTY_PERCENT;
+    }
+    else if (duty_percent > TIM3_PWM_MAX_DUTY_PERCENT)
+    {
+        clamped = TIM3_PWM_MAX_DUTY_PERCENT;
+    }
+    else
+    {
+        clamped = duty_percent;
+    }
+
+    period = __HAL_TIM_GET_AUTORELOAD(&s_tim3_handle);
+    pulse = (uint32_t)(((float)(period + 1U) * clamped) / 100.0f);
+
+    __HAL_TIM_SET_COMPARE(&s_tim3_handle, channel, pulse);
+
+    return HAL_TIM_PWM_Start(&s_tim3_handle, channel);
+}
+
+static void TIM3_PWM_EnableClocks(void)
+{
+    __HAL_RCC_TIM3_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+}
+
+static void TIM3_PWM_InitGPIO(uint32_t channel)
+{
+    GPIO_InitTypeDef gpio = {0};
+
+    gpio.Mode = GPIO_MODE_AF_PP;
+    gpio.Pull = GPIO_NOPULL;
+    gpio.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+
+    switch (channel)
+    {
+        case TIM_CHANNEL_1:
+            gpio.Pin = GPIO_PIN_6;
+            gpio.Alternate = GPIO_AF2_TIM3;
+            HAL_GPIO_Init(GPIOA, &gpio);
+            break;
+        case TIM_CHANNEL_2:
+            gpio.Pin = GPIO_PIN_7;
+            gpio.Alternate = GPIO_AF2_TIM3;
+            HAL_GPIO_Init(GPIOA, &gpio);
+            break;
+        case TIM_CHANNEL_3:
+            gpio.Pin = GPIO_PIN_0;
+            gpio.Alternate = GPIO_AF2_TIM3;
+            HAL_GPIO_Init(GPIOB, &gpio);
+            break;
+        case TIM_CHANNEL_4:
+            gpio.Pin = GPIO_PIN_1;
+            gpio.Alternate = GPIO_AF2_TIM3;
+            HAL_GPIO_Init(GPIOB, &gpio);
+            break;
+        default:
+            break;
+    }
+}
+
+static uint32_t TIM3_PWM_CalculatePeriod(uint32_t target_frequency_hz)
+{
+    RCC_ClkInitTypeDef clock_config;
+    uint32_t flash_latency;
+    uint32_t pclk1;
+    uint32_t timer_clock;
+    uint32_t period;
+
+    HAL_RCC_GetClockConfig(&clock_config, &flash_latency);
+    pclk1 = HAL_RCC_GetPCLK1Freq();
+
+    if (clock_config.APB1CLKDivider != RCC_HCLK_DIV1)
+    {
+        timer_clock = pclk1 * 2U;
+    }
+    else
+    {
+        timer_clock = pclk1;
+    }
+
+    if (target_frequency_hz == 0U)
+    {
+        return 0U;
+    }
+
+    period = (uint32_t)((timer_clock + (target_frequency_hz / 2U)) / target_frequency_hz) - 1U;
+
+    if (period > 0xFFFFU)
+    {
+        period = 0xFFFFU;
+    }
+
+    return period;
+}
+


### PR DESCRIPTION
## Summary
- expand the README with step-by-step instructions to integrate the TIM3 PWM helper into an STM32CubeIDE project
- clarify file placement, include configuration, and HAL initialisation calls needed to use the library from Cube-generated code

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4a6a2051083209e78ca54a5dd6f0b